### PR TITLE
Support list of scalars on execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The implementation of the library follow closely to the GraphQL Draft RFC Specif
     * [x] Variables
     * [ ] Union
     * [ ] Interface
+    * [ ] Safe parallel execution
 - [x] Fragment execution
     * [ ] Fragment Type
 - [x] Support Context


### PR DESCRIPTION
Querying a list of strings would previously return [{} {} {}] instead of ["0" "1" "2"] for the incremental test case.