### PR TITLE
Extend the parser to pass parser CAT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [instaparse "1.4.1"]
+                 [instaparse "1.4.3"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
   :profiles {:dev {:dependencies [[io.forward/yaml "1.0.3"]]}})

--- a/src/graphql.bnf
+++ b/src/graphql.bnf
@@ -58,8 +58,8 @@ Selection ::= Field <Ignored> | FragmentSpread <Ignored> | InlineFragment <Ignor
 Field ::= Alias? <Ignored> Name <Ignored> Arguments? <Ignored> Directives? SelectionSet?
 FragmentSpread ::= <"..."> FragmentName <Ignored> Directives?
 InlineFragment ::= <"..."> <Ignored> TypeCondition? Directives? SelectionSet
-TypeSystemDefinition ::= TypeDefinition | InterfaceDefinition | UnionDefinition | SchemaDefinition | EnumDefinition | InputDefinition | DirectiveDefinition
-TypeDefinition ::= <"type"> <Ignored> Name <Ignored> TypeImplements? <Ignored> <"{"> <Ignored> TypeFields <Ignored> <"}"> <Ignored>
+TypeSystemDefinition ::= TypeDefinition | InterfaceDefinition | UnionDefinition | SchemaDefinition | EnumDefinition | InputDefinition | DirectiveDefinition | TypeExtensionDefinition | ScalarDefinition
+TypeDefinition ::= <"type"> <Ignored> Name <Ignored> TypeImplements? <Ignored> <"{"> <Ignored> TypeFields* <Ignored> <"}"> <Ignored>
 TypeSystemType ::= "schema" | "scalar" | "type" | "interface" | "union" | "enum" | "input" | "extend" | "directive"
 TypeFields ::= TypeField | TypeField TypeFields
 TypeField ::= Name TypeFieldVariables? <":"> <Ignored> [TypeFieldType | TypeFieldTypeRequired] <Ignored>
@@ -71,9 +71,10 @@ TypeRequired ::= Type <"!">
 TypeFieldVariable ::= Name <":"> <Ignored> [Type | TypeRequired] <Ignored> TypeFieldVariableDefault?
 TypeFieldVariableDefault ::= <"="> <Ignored> [StringValue | BooleanValue | IntValue | FloatValue]
 TypeImplements ::= <"implements"> <Ignored> TypeNames
+UnionDefinition ::= <"union"> <Ignored> Name <Ignored> <"="> <Ignored> UnionTypeNames
+UnionTypeNames ::= Name <Ignored> | Name <Ignored> <"|"> <Ignored> UnionTypeNames
 TypeNames ::= Name | Name <Ignored> TypeNames
 InterfaceDefinition ::= <"interface"> <Ignored> Name <Ignored> <"{"> <Ignored> TypeFields <Ignored> <"}"> <Ignored>
-UnionDefinition ::= <"union"> <Ignored> Name <Ignored> <"="> <Ignored> Name <Ignored> <"|"> <Ignored> Name <Ignored>
 SchemaDefinition ::= <"schema"> <Ignored> <"{"> SchemaTypes <"}"> <Ignored>
 SchemaTypes ::= SchemaType+
 SchemaType ::= QueryType | MutationType
@@ -85,7 +86,11 @@ EnumField ::= <Ignored> Name <Ignored> EnumType?
 EnumType ::= <"@enum"> EnumTypeInt EnumValue <Ignored>
 EnumValue ::= <"("> <"value:"> <Ignored> IntValue <")">
 EnumTypeInt ::= "Int"
-InputDefinition ::= <"input"> <Ignored> Name <Ignored> <"{"> <Ignored> TypeFields <"}"> <Ignored>
+InputDefinition ::= <"input"> <Ignored> Name <Ignored> <"{"> <Ignored> InputTypeFields <"}"> <Ignored>
+InputTypeFields ::= InputTypeField | InputTypeField InputTypeFields
+InputTypeField ::= Name <":"> <Ignored> [TypeFieldType | TypeFieldTypeRequired] <Ignored>
 DirectiveDefinition ::= <"directive"> <Ignored> DirectiveName <Ignored> DirectiveOnName <Ignored>
 DirectiveName ::= <"@">Name
 DirectiveOnName ::= <"on"> <Ignored> Name
+TypeExtensionDefinition ::= <"extend"> <Ignored> TypeDefinition
+ScalarDefinition ::= <"scalar"> <Ignored> Name

--- a/src/graphql_clj/type.clj
+++ b/src/graphql_clj/type.clj
@@ -1,5 +1,4 @@
-(ns graphql-clj.type
-  (:require [clojure.java.io :as io]))
+(ns graphql-clj.type)
 
 (defn- type-system-type-filter-fn
   [type]
@@ -52,8 +51,7 @@
 
 (defn- create-type-system-enum [definition]
   (let [name (:name definition)
-        enum-fields (:enum-fields definition)
-        fields (create-type-system-fields enum-fields)]
+        enum-fields (:enum-fields definition)]
     (assert name "Enum definition name is NULL!")
     [name {:name name
            :kind :ENUM

--- a/test/cats/scenarios/parsing/schema_parser_test.clj
+++ b/test/cats/scenarios/parsing/schema_parser_test.clj
@@ -3,12 +3,29 @@
             [yaml.core :as yaml]
             [graphql-clj.parser :as parser]))
 
-(def schema-parser-tests (yaml/from-file "test/cats/scenarios/parsing/SchemaParser.yaml"))
+(defn- expectation->enum [t]
+  (->> (get t "then") keys first keyword))
+
+(defn- interpret-parsed [r]
+  (cond (:reason r)                :syntax-error
+        (:operation-definitions r) :passes
+        :else                      :parser-error))
+
+(defn- parse-query [t]
+  (let [q (get-in t ["given" "query"])
+        parsed (parser/parse q)]
+    {:query    q
+     :parsed   parsed
+     :expected (expectation->enum t)
+     :result   (interpret-parsed parsed)}))
+
+(def schema-parser-tests (get (yaml/from-file "test/cats/scenarios/parsing/SchemaParser.yaml") "tests"))
 
 (assert (not (nil? schema-parser-tests)) "No schema tests found!")
 
-(deftest test-schema-parser-tests
-  (testing "test SchemaParser.yml"
-    (doseq [t (get schema-parser-tests "tests")]
-      (let [query (get-in t ["given" "query"])]
-        (is (not (nil? (parser/parse query))))))))
+(def parser-results (map parse-query schema-parser-tests))
+
+(deftest schema-parser
+  (testing "SchemaParser.yml"
+    (doseq [{:keys [expected result] :as r} parser-results]
+      (is (= expected result)))))


### PR DESCRIPTION
Previously, the following CAT cases were failing:
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L14
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L36
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L44
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L123
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L139
* https://github.com/graphql-cats/graphql-cats/blob/master/scenarios/parsing/SchemaParser.yaml#L158